### PR TITLE
add webkit/moz/user-select: none

### DIFF
--- a/src/style.sass
+++ b/src/style.sass
@@ -20,7 +20,10 @@ $clock-placeholder-hands-color: #444444
 	position: relative
 	width: 120px
 	height: 40px
-	
+	-webkit-user-select: none
+	-moz-user-select: none
+	user-select: none
+
 	*
 		box-sizing: border-box
 			


### PR DESCRIPTION
Prevent users from selecting the time display numbers.